### PR TITLE
added Ctors with "uid"

### DIFF
--- a/src/main/java/com/yegor256/xsline/StOfTrain.java
+++ b/src/main/java/com/yegor256/xsline/StOfTrain.java
@@ -44,4 +44,15 @@ public final class StOfTrain extends StEnvelope {
         );
     }
 
+    /**
+     * Ctor.
+     * @param uid The UID to use
+     * @param train The train
+     */
+    public StOfTrain(final String uid, final Train<Shift> train) {
+        super(
+            new StSequence(uid, train)
+        );
+    }
+
 }


### PR DESCRIPTION
We need to specify "uid" parameter for `StSequence`, as it was provided in old `StOfTrain`.

Also, it can make simpler (or may be faster) [these](https://github.com/objectionary/eo/blob/master/eo-parser/src/main/java/org/eolang/parser/ParsingTrain.java#L105-L107) lines, without additionally encapsulating `StSequence` by `StLambda` only to set "uid".

@yegor256 WDYT?