### PR TITLE
Upgrade dependencies, plugins, and GitHub Actions to latest stable

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download actionlint
         id: get_actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -12,19 +12,19 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 21
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-
       - run: mvn install -Pjacoco
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./target/site/jacoco/jacoco.xml

--- a/.github/workflows/copyrights.yml
+++ b/.github/workflows/copyrights.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: yegor256/copyrights-action@0.0.8
+      - uses: actions/checkout@v6
+      - uses: yegor256/copyrights-action@0.0.12

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -18,5 +18,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: DavidAnson/markdownlint-cli2-action@v20.0.0
+      - uses: actions/checkout@v6
+      - uses: DavidAnson/markdownlint-cli2-action@v23

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -19,12 +19,12 @@ jobs:
         os: [ ubuntu-24.04, windows-2022, macos-15 ]
         java: [ 17, 21 ]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oss-review-toolkit/ort-ci-github-action@v1
         with:
           allow-dynamic-versions: 'true'

--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: volodya-lombrozo/pdd-action@master

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: fsfe/reuse-action@v5
+      - uses: actions/checkout@v6
+      - uses: fsfe/reuse-action@v6

--- a/.github/workflows/simian.yml
+++ b/.github/workflows/simian.yml
@@ -15,8 +15,8 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 17

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -15,19 +15,19 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: 'zulu'
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: crate-ci/typos@v1.32.0
+      - uses: actions/checkout@v6
+      - uses: crate-ci/typos@v1.46.0

--- a/.github/workflows/up.yml
+++ b/.github/workflows/up.yml
@@ -10,12 +10,12 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: |-
           git fetch --tags --force && \
           latest=$(git tag --sort=creatordate | tail -1) && \
           sed -E -i "s/<version>[^<]+/<version>${latest}/g" README.md
-      - uses: peter-evans/create-pull-request@v7
+      - uses: peter-evans/create-pull-request@v8
         with:
           sign-commits: true
           commit-message: 'new version in README'

--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: g4s8/xcop-action@master

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ibiqlik/action-yamllint@v3
         with:
           config-file: .yamllint.yml

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-matchers</artifactId>
-      <version>1.8.0</version>
+      <version>1.9.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -233,7 +233,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.27.5</version>
+            <version>0.27.6</version>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
@yegor256 this PR brings every direct dependency, plugin, and GitHub Actions reference up to its latest stable release, and the full Maven + qulice build was verified locally on JDK 21 after each change.

## Changes

### `pom.xml`
- `com.jcabi:jcabi-matchers` 1.8.0 -> 1.9.0
- `com.qulice:qulice-maven-plugin` 0.27.5 -> 0.27.6 (qulice profile)

### `.github/workflows/*`
- `actions/checkout` v4 -> v6
- `actions/setup-java` v4 -> v5
- `actions/cache` v4 -> v5
- `fsfe/reuse-action` v5 -> v6
- `codecov/codecov-action` v5 -> v6
- `DavidAnson/markdownlint-cli2-action` v20.0.0 -> v23
- `crate-ci/typos` v1.32.0 -> v1.46.0
- `peter-evans/create-pull-request` v7 -> v8
- `yegor256/copyrights-action` 0.0.8 -> 0.0.12

## CI status

All 16 relevant CI jobs are green on this PR:

- `mvn` matrix (ubuntu-24.04, macos-15, windows-2022) x (Java 17, 21) - 6/6 pass
- `actionlint`, `copyrights`, `markdown-lint`, `pdd`, `reuse`, `simian`, `typos`, `xcop`, `yamllint`, `codecov` - all pass

The only red check is `ort`, which has been failing continuously on `master` and on every Renovate/dependency PR since at least February 2026 (run history shows the same failure on 25+ consecutive runs, including direct pushes to `master`). The failure pre-exists this PR and is unrelated to it - the action exits with code 2 and the diagnostic artifact is hosted on Azure Blob storage that isn't reachable from this environment, so I couldn't dig into the underlying violation. Happy to follow up in a dedicated PR once the root cause is identified.

## Test plan

- [x] `mvn --errors --batch-mode clean install -Pqulice` passes locally on JDK 21
- [x] All 16 non-ort CI jobs pass on this PR
- [x] `ort` confirmed pre-existing failure (failing on master and every PR for months)