### PR TITLE
#283: drop vulnerable log4j 1.2.17 to fix ort CI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,12 +99,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-matchers</artifactId>
       <version>1.9.0</version>


### PR DESCRIPTION
The ort workflow has been failing on every push to master because the policy evaluator finds a `VULNERABILITY_IN_DEPENDENCY` violation on `Maven:log4j:log4j:1.2.17`, and the action is configured with `fail-on: violations`. The package is end-of-life and carries the CVE-2019-17571 deserialization vulnerability that drives the failure.

The explicit `log4j:log4j:1.2.17` test dependency is also redundant: `org.slf4j:slf4j-reload4j:2.0.17` already pulls in `ch.qos.reload4j:reload4j:1.2.22`, the maintained drop-in replacement that exposes the same `org.apache.log4j.*` classes used by `src/test/resources/log4j.properties`. Dropping the obsolete coordinate removes the violation and leaves reload4j as the single backend.

Ran `mvn test` locally on the patched tree: 45 tests passed, 0 failures, 0 errors. The `log4j.properties` configuration still resolves against reload4j's `org.apache.log4j.ConsoleAppender`.

Closes #283