### PR TITLE
#285: resolve StSchema's XSD via StSchema.class, not StClasspath.class

### DIFF
--- a/src/main/java/com/yegor256/xsline/StSchema.java
+++ b/src/main/java/com/yegor256/xsline/StSchema.java
@@ -138,7 +138,7 @@ public final class StSchema extends StEnvelope {
      * @return XSD
      */
     private static XML make(final String path) {
-        final URL url = StClasspath.class.getResource(path);
+        final URL url = StSchema.class.getResource(path);
         if (url == null) {
             throw new IllegalArgumentException(
                 String.format(


### PR DESCRIPTION
Closes #285.

## Problem

`StSchema.make(String)` (`src/main/java/com/yegor256/xsline/StSchema.java:141`) resolved the XSD location with `StClasspath.class.getResource(path)`. This only works because `StSchema` and `StClasspath` happen to share the `com.yegor256.xsline` package, so the resolution root is incidentally identical. It is fragile: moving `StClasspath` to a different package, splitting the module, or repackaging into a shaded jar would silently change the lookup root for `StSchema` and leave the XSD constructor failing with a misleading `IllegalArgumentException: Path '...' not found in classpath`. It also blurs the dependency graph — `StSchema` has no functional reason to reference `StClasspath`.

## Fix

One-token change: resolve the resource through `StSchema.class`, the class that actually owns the lookup. `StClasspath.make` already follows this convention and is left untouched.

## Note on testing

There is no behavioural change today (both classes share a package and the public API/tests use absolute classpath paths, which are classloader-relative), so no regression test can distinguish the two forms without restructuring packages — this matches the issue, which describes it as a one-character correctness fix. The existing `StSchemaTest` (3 tests) stays green.

Verified locally with `mvn test -Dtest=StSchemaTest` and `mvn test-compile qulice:check -Pqulice` (both green).