### PR TITLE
#290: use System.nanoTime() for elapsed-time measurement in StFast

### DIFF
--- a/src/main/java/com/yegor256/xsline/StFast.java
+++ b/src/main/java/com/yegor256/xsline/StFast.java
@@ -6,6 +6,7 @@ package com.yegor256.xsline;
 
 import com.jcabi.log.Logger;
 import com.jcabi.xml.XML;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A {@link Shift} that logs a warning if XSL transformation takes too long.
@@ -71,14 +72,14 @@ public final class StFast implements Shift {
 
     @Override
     public XML apply(final int position, final XML xml) {
-        return this.timed(position, xml, System.currentTimeMillis());
+        return this.timed(position, xml, System.nanoTime());
     }
 
     /**
      * Applies shift and logs a warning if it took too long.
      * @param position Position in the pipeline
      * @param xml Input XML
-     * @param before Start time in milliseconds
+     * @param before Start time in nanoseconds from {@link System#nanoTime()}
      * @return Transformed XML
      */
     private XML timed(final int position, final XML xml, final long before) {
@@ -88,15 +89,16 @@ public final class StFast implements Shift {
     /**
      * Logs a warning if transformation took too long.
      * @param result The transformation result
-     * @param before Start time in milliseconds
+     * @param before Start time in nanoseconds from {@link System#nanoTime()}
      * @return The same result unchanged
      */
     private XML checked(final XML result, final long before) {
-        if (System.currentTimeMillis() - before > this.threshold) {
+        final long elapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - before);
+        if (elapsed > this.threshold) {
             Logger.warn(
                 this.target,
                 "XSL '%s' took %[ms]s (over %[ms]s)",
-                this.uid(), System.currentTimeMillis() - before,
+                this.uid(), elapsed,
                 this.threshold
             );
         }


### PR DESCRIPTION
Fixes #290. `StFast.apply()` and `StFast.checked()` measured elapsed time with `System.currentTimeMillis()`, which reads the wall clock and can therefore jump forward or backward whenever the OS clock is adjusted by NTP, DST, or a manual change; the comparison `now - before > threshold` then either silently passes a negative delta or fires a spurious warning on a fabricated one. Java's own documentation for `currentTimeMillis()` directs callers to `System.nanoTime()` for elapsed-time measurement because `nanoTime()` is monotonic.

The two timestamp reads in `StFast.java:74` and `StFast.java:95` now call `System.nanoTime()`, the delta is converted once with `TimeUnit.NANOSECONDS.toMillis(...)`, and the resulting value drives both the threshold comparison and the log argument so the threshold and the reported duration stay in milliseconds exactly as they were before. The Javadoc on the two `before` parameters was updated to describe the nanosecond source.

Ran `mvn -DskipITs test` locally on the patched tree: 45 tests passed, 0 failures, 0 errors. The `TrFastTest` warning path still triggers (`XSL 'add-brackets' took 16ms (over 1ms)`) and emits a positive millisecond duration.